### PR TITLE
docs(index): add link to packages

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
 </head>
 <body>
   <p>
+    Documentation: <a href="http://scijs.net/packages">scijs packages</a>
+  </p>
+  <p>
     GitHub: <a href="https://github.com/scijs">@scijs</a>
   </p>
   <p>


### PR DESCRIPTION
Fixes #1

When navigating to the main domain, www.scijs.net, it looks broken or abandoned.  This adds a link to the package documentation.